### PR TITLE
Bootable containers

### DIFF
--- a/cmd/mobynit/main.go
+++ b/cmd/mobynit/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	_ "github.com/docker/docker/daemon/graphdriver/aufs"
+	_ "github.com/docker/docker/daemon/graphdriver/overlay2"
+	"github.com/docker/docker/layer"
+	"github.com/docker/docker/pkg/idtools"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	LAYER_ROOT = "/docker"
+	PIVOT_PATH = "/mnt/sysroot"
+)
+
+func mountContainer(containerID string) string {
+	if err := unix.Mount("", "/", "", unix.MS_REMOUNT, ""); err != nil {
+		log.Fatal("error remounting root as read/write:", err)
+	}
+	defer unix.Mount("", "/", "", unix.MS_REMOUNT | unix.MS_RDONLY, "")
+
+	if err := os.MkdirAll("/dev/shm", os.ModePerm); err != nil {
+		log.Fatal("creating /dev/shm failed:", err)
+	}
+
+	if err := unix.Mount("shm", "/dev/shm", "tmpfs", 0, ""); err != nil {
+		log.Fatal("error mounting /dev/shm:", err)
+	}
+	defer unix.Unmount("/dev/shm", unix.MNT_DETACH)
+
+	ls, err := layer.NewStoreFromOptions(layer.StoreOptions{
+		StorePath:                 LAYER_ROOT,
+		MetadataStorePathTemplate: filepath.Join(LAYER_ROOT, "image", "%s", "layerdb"),
+		IDMappings:                &idtools.IDMappings{},
+		GraphDriver:               "aufs",
+		Platform:                  "linux",
+	})
+	if err != nil {
+		log.Fatal("error loading layer store:", err)
+	}
+
+	rwlayer, err := ls.GetRWLayer(containerID)
+	if err != nil {
+		log.Fatal("error getting container layer:", err)
+	}
+
+	newRoot, err := rwlayer.Mount("")
+	if err != nil {
+		log.Fatal("error mounting container fs:", err)
+	}
+
+	if err := unix.Mount("", newRoot, "", unix.MS_REMOUNT, ""); err != nil {
+		log.Fatal("error remounting container as read/write:", err)
+	}
+	defer unix.Mount("", newRoot, "", unix.MS_REMOUNT | unix.MS_RDONLY, "")
+
+	if err := os.MkdirAll(filepath.Join(newRoot, PIVOT_PATH), os.ModePerm); err != nil {
+		log.Fatal("creating /mnt/sysroot failed:", err)
+	}
+
+	return newRoot
+}
+
+func main() {
+	rawID, err := ioutil.ReadFile("/current/container_id")
+	if err != nil {
+		log.Fatal("could not get container ID:", err)
+	}
+	containerID := strings.TrimSpace(string(rawID))
+
+	newRoot := mountContainer(containerID)
+
+	if err := syscall.PivotRoot(newRoot, filepath.Join(newRoot, PIVOT_PATH)); err != nil {
+		log.Fatal("error while pivoting root:", err)
+	}
+
+	if err := unix.Chdir("/"); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := syscall.Exec("/sbin/init", os.Args, os.Environ()); err != nil {
+		log.Fatal("error executing init:", err)
+	}
+}

--- a/cmd/mobynit/main.go
+++ b/cmd/mobynit/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"io/ioutil"
 	"log"
 	"os"
@@ -19,6 +20,13 @@ const (
 	LAYER_ROOT = "/docker"
 	PIVOT_PATH = "/mnt/sysroot"
 )
+
+var graphDriver string
+
+func init() {
+	flag.StringVar(&graphDriver, "storage-driver", "aufs", "Storage driver to use")
+	flag.StringVar(&graphDriver, "s", "aufs", "Storage driver to use")
+}
 
 func mountContainer(containerID string) string {
 	if err := unix.Mount("", "/", "", unix.MS_REMOUNT, ""); err != nil {
@@ -39,7 +47,7 @@ func mountContainer(containerID string) string {
 		StorePath:                 LAYER_ROOT,
 		MetadataStorePathTemplate: filepath.Join(LAYER_ROOT, "image", "%s", "layerdb"),
 		IDMappings:                &idtools.IDMappings{},
-		GraphDriver:               "aufs",
+		GraphDriver:               graphDriver,
 		Platform:                  "linux",
 	})
 	if err != nil {
@@ -69,6 +77,8 @@ func mountContainer(containerID string) string {
 }
 
 func main() {
+	flag.Parse()
+
 	rawID, err := ioutil.ReadFile("/current/container_id")
 	if err != nil {
 		log.Fatal("could not get container ID:", err)

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -17,6 +17,9 @@ import (
 
 // createContainerPlatformSpecificSettings performs platform specific container create functionality
 func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
+	if hostConfig.Runtime == "bare" {
+		return nil
+	}
 	if err := daemon.Mount(container); err != nil {
 		return err
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -641,6 +641,7 @@ func verifyDaemonSettings(conf *config.Config) error {
 		conf.Runtimes = make(map[string]types.Runtime)
 	}
 	conf.Runtimes[config.StockRuntimeName] = types.Runtime{Path: DefaultRuntimeBinary}
+	conf.Runtimes["bare"] = types.Runtime{}
 
 	return nil
 }


### PR DESCRIPTION
This PR introduces another type of containers, namely bootable containers, that are meant to be used to bootstrap a system. The distinction is achieved by specifying the `bare` runtime instead of the default `runc`. This disables some actions performed by Docker that interfere with the boot process.

This PR also adds a new command, mobynit, which is meant to be statically compiled and run as PID 1 of a system running bootable containers. This commands contains the absolute minimal code to assemble the root partition of a bootable container, pivot root, and start the normal init process.

The sysroot is mounted at `/mnt/sysroot` of the container mount namespace to allow the bootable container  to update itself. 