### PR TITLE
Meta resin patches

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -144,6 +144,10 @@ func (container *Container) FromDisk() error {
 		return err
 	}
 
+	if container.Config == nil {
+		return fmt.Errorf("Invalid container config.json, missing Config property")
+	}
+
 	// Ensure the platform is set if blank. Assume it is the platform of the
 	// host OS if not, to ensure containers created before multiple-platform
 	// support are migrated

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -470,6 +470,10 @@ func (a *Driver) ApplyDiff(id, parent string, diff io.Reader) (size int64, err e
 		return
 	}
 
+	// FIXME: Instead of syncing all the filesystems we should be fsyncing each
+	// file as the tar archive gets unpacked
+	syscall.Sync()
+
 	return a.DiffSize(id, parent)
 }
 

--- a/daemon/graphdriver/overlay2/overlay.go
+++ b/daemon/graphdriver/overlay2/overlay.go
@@ -670,6 +670,10 @@ func (d *Driver) ApplyDiff(id string, parent string, diff io.Reader) (size int64
 		return 0, err
 	}
 
+	// FIXME: Instead of syncing all the filesystems we should be fsyncing each
+	// file as the tar archive gets unpacked
+	syscall.Sync()
+
 	return directory.Size(applyDir)
 }
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/pkg/pools"
 	"github.com/docker/docker/pkg/promise"
 	"github.com/docker/docker/pkg/system"
+	"golang.org/x/sys/unix"
 )
 
 type (
@@ -622,6 +623,20 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			return err
 		}
 	}
+
+	if hdr.Typeflag == tar.TypeReg || hdr.Typeflag == tar.TypeRegA {
+		file, err := os.Open(path)
+		if err != nil {
+			file.Close()
+			return err
+		}
+		if err := unix.Fadvise(int(file.Fd()), 0, 0, unix.FADV_DONTNEED); err != nil {
+			file.Close()
+			return err
+		}
+		file.Close()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This repo will become the canonical source for the container engine we ship in resinOS. This PR transfers the existing patches from https://github.com/resin-os/meta-resin/tree/v2.2.0/meta-resin-common/recipes-containers/docker/docker and adapts them to the 17.06 tree.