### PR TITLE
Mobynit improvements

### DIFF
--- a/cmd/mobynit/main.go
+++ b/cmd/mobynit/main.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 
 	_ "github.com/docker/docker/daemon/graphdriver/aufs"
@@ -79,11 +77,11 @@ func mountContainer(containerID string) string {
 func main() {
 	flag.Parse()
 
-	rawID, err := ioutil.ReadFile("/current/container_id")
+	current, err := os.Readlink("/current")
 	if err != nil {
 		log.Fatal("could not get container ID:", err)
 	}
-	containerID := strings.TrimSpace(string(rawID))
+	containerID := filepath.Base(current)
 
 	newRoot := mountContainer(containerID)
 

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -17,9 +17,6 @@ import (
 
 // createContainerPlatformSpecificSettings performs platform specific container create functionality
 func (daemon *Daemon) createContainerPlatformSpecificSettings(container *container.Container, config *containertypes.Config, hostConfig *containertypes.HostConfig) error {
-	if hostConfig.Runtime == "bare" {
-		return nil
-	}
 	if err := daemon.Mount(container); err != nil {
 		return err
 	}


### PR DESCRIPTION
There are tree changes here.

First, I switched the root fs layout a bit and made `/current` to be a symlink to a `/hostapps/<container_id>` directory instead of being itself a directory and contain a `container_id` file. The reason for this change is to make changing what the current host app is atomic. A symlink can be atomically renamed to point somewhere else.

Second, any mounts that were performed by an initrd before mobynit had a chance to run will be moved to the new root before pivoting.

Third, reverted shortcircuiting of volume creation for bare containers. Having them there makes things on the host OS update side a bit easier. 