### PR TITLE
Build improvements

### DIFF
--- a/hack/make/binary-rce-docker
+++ b/hack/make/binary-rce-docker
@@ -7,7 +7,7 @@ set -e
 	source "${MAKEDIR}/.binary-setup"
 	export BINARY_SHORT_NAME="$DOCKER_RCE_BINARY_NAME"
 	export GO_PACKAGE='github.com/docker/docker/cmd/rce'
-	export LDFLAGS="$LDFLAGS -s"
+	export LDFLAGS="$LDFLAGS"
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	source "${MAKEDIR}/.binary"
 	copy_binaries "$DEST" 'hash'

--- a/hack/make/dynbinary-rce-docker
+++ b/hack/make/dynbinary-rce-docker
@@ -8,7 +8,7 @@ set -e
 	export BINARY_SHORT_NAME="$DOCKER_RCE_BINARY_NAME"
 	export GO_PACKAGE='github.com/docker/docker/cmd/rce'
 	export IAMSTATIC='false'
-	export LDFLAGS="$LDFLAGS -s"
+	export LDFLAGS="$LDFLAGS"
 	export LDFLAGS_STATIC_DOCKER=''
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary

--- a/hack/make/dynbinary-rce-docker
+++ b/hack/make/dynbinary-rce-docker
@@ -7,8 +7,11 @@ set -e
 	source "${MAKEDIR}/.binary-setup"
 	export BINARY_SHORT_NAME="$DOCKER_RCE_BINARY_NAME"
 	export GO_PACKAGE='github.com/docker/docker/cmd/rce'
+	export IAMSTATIC='false'
 	export LDFLAGS="$LDFLAGS -s"
+	export LDFLAGS_STATIC_DOCKER=''
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
+	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary
 	source "${MAKEDIR}/.binary"
 	copy_binaries "$DEST" 'hash'
 


### PR DESCRIPTION
Create two flavours of the build, dynamic and static, and also revert stripping the binary. This can be done by downstream users.