### PR TITLE
Final tweaks

### DIFF
--- a/cmd/mobynit/main.go
+++ b/cmd/mobynit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	LAYER_ROOT = "/docker"
-	PIVOT_PATH = "/mnt/sysroot"
+	PIVOT_PATH = "/mnt/sysroot/active"
 )
 
 var graphDriver string

--- a/cmd/mobynit/main.go
+++ b/cmd/mobynit/main.go
@@ -28,11 +28,6 @@ func init() {
 }
 
 func mountContainer(containerID string) string {
-	if err := unix.Mount("", "/", "", unix.MS_REMOUNT, ""); err != nil {
-		log.Fatal("error remounting root as read/write:", err)
-	}
-	defer unix.Mount("", "/", "", unix.MS_REMOUNT | unix.MS_RDONLY, "")
-
 	if err := os.MkdirAll("/dev/shm", os.ModePerm); err != nil {
 		log.Fatal("creating /dev/shm failed:", err)
 	}
@@ -86,6 +81,10 @@ func main() {
 		log.Fatal("could not get container ID:", err)
 	}
 	containerID := filepath.Base(current)
+
+	if err := unix.Mount("", "/", "", unix.MS_REMOUNT, ""); err != nil {
+		log.Fatal("error remounting root as read/write:", err)
+	}
 
 	newRoot := mountContainer(containerID)
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -14,7 +14,7 @@ github.com/tchap/go-patricia v2.2.6
 github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3
 # forked golang.org/x/net package includes a patch for lazy loading trace templates
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
-golang.org/x/sys c200b10b5d5e122be351b67af224adc6128af5bf
+golang.org/x/sys 237befd9ffade4114d3e63795272b7e08ea55e83 https://github.com/resin-os/golang-sys
 github.com/docker/go-units 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 github.com/docker/go-connections 3ede32e2033de7505e6500d6c868c2b9ed9f169d
 golang.org/x/text f72d8390a633d5dfb0cc84043294db9f6c935756


### PR DESCRIPTION
Following the desired resinOS scheme, change the sysroot directory to `/mnt/sysroot/active`, always mount it read/write, and update `golang/x/sys` to include `unix.Fadvise()` support for aarch64