### PR TITLE
delta: remove false assumption about src image

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -376,7 +376,7 @@ func (daemon *Daemon) DeltaCreate(deltaSrc, deltaDest string) (string, error) {
 
 		// We're only interested in layers that are different. Push empty
 		// layers for common layers
-		if srcImg.RootFS.DiffIDs[i] == diffID {
+		if i < len(srcImg.RootFS.DiffIDs) && srcImg.RootFS.DiffIDs[i] == diffID {
 			layerData, _ = layer.EmptyLayer.TarStream()
 			platform = layer.EmptyLayer.Platform()
 		} else {


### PR DESCRIPTION
Previously the code assumed the source image had at least as many layers
as the destination image.
